### PR TITLE
allow multiple heroku install directives

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+# Overview
+
+A brief description of the change
+
+## Story
+
+[#12345](https://www.pivotaltracker.com/story/show/12345)
+
+## Things That I Tested
+
+List out any scenarios or items that were tested manually
+
+## Where More Testing Might Be Necessary
+
+List any outliers, edge cases or potential side effects from this change
+
+## Implementation Notes
+
+Any technical decisions, thoughts, concerns, etc
+
+## Dependencies
+
+List any stories, tasks or other PRs that might block this change from being merged
+
+## Code Review Best Practices
+
+Use [code best practices](https://github.com/b-lab-org/assessment-api/wiki/engineering-code-best-practices) for PR reviews

--- a/bin/compile
+++ b/bin/compile
@@ -490,6 +490,9 @@ case "${TOOL}" in
 
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); }}' ${goMOD})}
+
+        step "current pkgs is ${pkgs}"
+
         if [ -z "${pkgs}" ]; then
             pkgs=$(mainPackagesInModule)
             if [ -z "${pkgs}" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -383,7 +383,6 @@ setupGOPATH() {
 }
 
 installPkgs() {
-    step "current packages are ${pkgs}"
     for pkg in ${pkgs}; do
         step "Running: go install -v ${FLAGS[@]} ${pkg}"
         go install -v "${FLAGS[@]}" ${pkg} 2>&1

--- a/bin/compile
+++ b/bin/compile
@@ -489,7 +489,7 @@ case "${TOOL}" in
         fi
 
         step "Determining packages to install"
-        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); }}' ${goMOD})}
         if [ -z "${pkgs}" ]; then
             pkgs=$(mainPackagesInModule)
             if [ -z "${pkgs}" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -494,8 +494,6 @@ case "${TOOL}" in
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); }}' ${goMOD})}
 
-        step "current pkgs are ${pkgs}" 
-
         if [ -z "${pkgs}" ]; then
             pkgs=$(mainPackagesInModule)
             if [ -z "${pkgs}" ]; then
@@ -538,8 +536,6 @@ case "${TOOL}" in
             bin/go-pre-compile
         fi
 
-        step "pkgs before install ${pkgs}"
-
         installPkgs
 
         if [[ -f bin/go-post-compile ]]; then
@@ -568,7 +564,8 @@ case "${TOOL}" in
         fi
 
         step "Determining packages to install"
-        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goWork})}
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); }}' ${goWork})}
+        
         if [ -z "${pkgs}" ]; then
             pkgs=$(mainPackagesInModule)
             if [ -z "${pkgs}" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -383,6 +383,7 @@ setupGOPATH() {
 }
 
 installPkgs() {
+    step "current packages are ${pkgs}"
     for pkg in ${pkgs}; do
         step "Running: go install -v ${FLAGS[@]} ${pkg}"
         go install -v "${FLAGS[@]}" ${pkg} 2>&1

--- a/bin/compile
+++ b/bin/compile
@@ -383,8 +383,10 @@ setupGOPATH() {
 }
 
 installPkgs() {
-    step "Running: go install -v ${FLAGS[@]} ${pkgs}"
-    go install -v "${FLAGS[@]}" ${pkgs} 2>&1
+    for pkg in ${pkgs}; do
+        step "Running: go install -v ${FLAGS[@]} ${pkg}"
+        go install -v "${FLAGS[@]}" ${pkg} 2>&1
+    done
 }
 
 loadEnvDir "${env_dir}"
@@ -490,8 +492,6 @@ case "${TOOL}" in
 
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); }}' ${goMOD})}
-
-        step "current pkgs is ${pkgs}"
 
         if [ -z "${pkgs}" ]; then
             pkgs=$(mainPackagesInModule)

--- a/bin/compile
+++ b/bin/compile
@@ -494,6 +494,8 @@ case "${TOOL}" in
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); }}' ${goMOD})}
 
+        step "current pkgs are ${pkgs}" 
+
         if [ -z "${pkgs}" ]; then
             pkgs=$(mainPackagesInModule)
             if [ -z "${pkgs}" ]; then
@@ -535,6 +537,8 @@ case "${TOOL}" in
             chmod a+x bin/go-pre-compile
             bin/go-pre-compile
         fi
+
+        step "pkgs before install ${pkgs}"
 
         installPkgs
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -874,7 +874,8 @@ testGlideMassageVendor() {
   assertCaptured "Installing go"
   assertCaptured "Installing glide"
   assertCaptured "Fetching any unsaved dependencies (glide install)"
-  assertCaptured "Running: go install -v -tags heroku . github.com/heroku/fixture/vendor/github.com/mattes/migrate"
+  assertCaptured "Running: go install -v -tags heroku ."
+  assertCaptured "Running: go install -v -tags heroku github.com/heroku/fixture/vendor/github.com/mattes/migrate"
   assertCaptured "github.com/heroku/fixture"
   assertCaptured "github.com/heroku/fixture/vendor/github.com/fatih/color/vendor/github.com/mattn/go-colorable"
   assertCaptured "github.com/heroku/fixture/vendor/github.com/fatih/color/vendor/github.com/mattn/go-isatty"
@@ -1051,7 +1052,7 @@ testGodepBasicGo14() {
   assertBuildDirFileExists ".profile.d/concurrency.sh"
 }
 
-testGodepCGOVendored(){
+testGodepCGOVendored() {
   fixture "godep-cgo-vendored"
 
   env "CGO_CFLAGS" '-I${build_dir}/vendor/include'
@@ -1076,8 +1077,9 @@ testGodepMassageVendor() {
   compile
   assertCaptured "Checking Godeps/Godeps.json file."
   assertCaptured "Installing go"
-  assertCaptured "Running: go install -v -tags heroku . github.com/heroku/fixture/vendor/github.com/mattes/migrate"
+  assertCaptured "Running: go install -v -tags heroku ."
   assertCaptured "github.com/heroku/fixture"
+  assertCaptured "Running: go install -v -tags heroku github.com/heroku/fixture/vendor/github.com/mattes/migrate"
   assertCaptured "github.com/heroku/fixture/vendor/github.com/mattn/go-isatty"
   assertCaptured "github.com/heroku/fixture/vendor/github.com/shiena/ansicolor"
   assertCaptured "github.com/heroku/fixture/vendor/github.com/fatih/color"
@@ -1253,7 +1255,7 @@ testGodepLDSymbolValue() {
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertCompiledBinaryOutputs "fixture" "fixture"
-#  assertTrue "Binary has the right value" '[ "$(${compile_dir}/bin/fixture)" = "fixture" ]'
+  #  assertTrue "Binary has the right value" '[ "$(${compile_dir}/bin/fixture)" = "fixture" ]'
 }
 
 # # Older versions of Go have a different format for specifying linked flags


### PR DESCRIPTION
# Overview
This PR updates our fork of the `heroku-buildpack-go` project to allow installation of multiple pkgs via the 
`//+heroku install pkgName` directive.

## Story
* n/a

## Things That I Tested
* deployed buildpack of this branch to `analytics-api-staging` dyno
* deployed `assessment-api#db-updates` branch
* multiple install directives are successfully run via
```
// +heroku install ./analytics/cmd/...
// +heroku install github.com/rubenv/sql-migrate/...@v1.2.0
```

## Where More Testing Might Be Necessary
* I'll do some QA on identity and assessment staging environments to ensure this isn't a breaking change.

## Implementation Notes
* Normally, we would have just been able to run something like `// +heroku install ./anaytics/cmd/.. github.com/rubenv/sql-migrate/...@v1.2.0`. However, this fails due to a version mismatch between the packages. Based on [this](https://github.com/golang/go/issues/51196#issuecomment-1040720042) comment from a go maintainer, its recommended that you run `go install` multiple times, and this is expected behavior.
* the `awk` command used to interpolate the `//+heroku install` directive terminates early after 1 loop. Removing the early `exit` will gather every instance of the `//+heroku install` directive instead of just the 1st. I'm unsure if this will break anything else, but the `pkgs` variable seems like it was intended to be used for multiple packages based on other usages of for loops in the script.
* I attempted to use the already built in functionality for `bin/go-pre-compile` and `bin-go-post-compile`, but was unable to get it working. I opened an issue in the original heroku repo [here](https://github.com/heroku/heroku-buildpack-go/issues/505)

## Dependencies
* n/a

## Code Review Best Practices

Use [code best practices](https://github.com/b-lab-org/assessment-api/wiki/engineering-code-best-practices) for PR reviews